### PR TITLE
[FE-36] 모달 공통 컴포넌트 구현 

### DIFF
--- a/src/pages/mypage/mypage.tsx
+++ b/src/pages/mypage/mypage.tsx
@@ -25,5 +25,5 @@ const Container = styled.div``;
 const ModalWrapper = styled.div`
   width: 300px;
   height: 300px;
-  background-color: skyblue;
+  background-color: white;
 `;

--- a/src/pages/mypage/mypage.tsx
+++ b/src/pages/mypage/mypage.tsx
@@ -1,5 +1,29 @@
-export default function Mypage() {
-  return <div>mypage</div>;
+import Modal from "@/shared/components/modal/Modal";
+import useToggle from "@/shared/hooks/useToggle";
+import styled from "@emotion/styled";
+
+function Mypage() {
+  const { isOpen, toggle } = useToggle();
+
+  return (
+    <Container>
+      <button onClick={toggle}>trigger</button>
+
+      <Modal isOpen={isOpen} toggle={toggle}>
+        <ModalWrapper>
+          <h1>hi</h1>
+        </ModalWrapper>
+      </Modal>
+    </Container>
+  );
 }
 
 export { Mypage };
+
+const Container = styled.div``;
+
+const ModalWrapper = styled.div`
+  width: 300px;
+  height: 300px;
+  background-color: skyblue;
+`;

--- a/src/shared/components/modal/Modal.tsx
+++ b/src/shared/components/modal/Modal.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { keyframes } from "@emotion/react";
+import styled from "@emotion/styled";
+import { IModalProps } from "@/shared/types/components.types";
+
+/**
+ * Modal 컴포넌트는 모달을 렌더링합니다.
+ *
+ * @param {boolean} isOpen - 모달이 열려 있는지 여부를 나타내는 상태
+ * @param {() => void} toggle - 모달의 열림/닫힘 상태를 토글하는 훅
+ * @param {ReactNode} children - 모달의 내용
+ * 
+ * @example
+ * 
+ * ```tsx
+export function ModalTestPage() {
+  const { isOpen, toggle } = useToggle();
+
+  return (
+    <div>
+      <button onClick={toggle}>Modal Open</button>
+
+      <Modal isOpen={isOpen} toggle={toggle}>
+        <ModalWrapper>
+          // 모달 내용
+        </ModalWrapper>
+      </Modal>
+    </div>
+  );
+}
+ * ```
+ * 
+ */
+
+export default function Modal({ children, isOpen, toggle }: IModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  // 모달 열고 닫는 기본 로직
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current?.showModal();
+      dialogRef.current?.scrollTo({
+        top: 0,
+      });
+      document.body.style.overflow = "hidden"; // 배경 스크롤 방지
+    } else {
+      const timer = setTimeout(() => {
+        dialogRef.current?.close();
+        document.body.style.overflow = ""; // 배경 스크롤 허용
+      }, 200); // 애니메이션 시간보다 조금 더 빠르게
+
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  const handleClickOutside = (e: React.MouseEvent<HTMLDialogElement>) => {
+    // 모달 바깥을 클릭하면 닫히도록
+    if ((e.target as any).nodeName === "DIALOG") {
+      toggle();
+    }
+  };
+
+  return createPortal(
+    <Dialog $isOpen={isOpen} onClick={handleClickOutside} ref={dialogRef}>
+      {children}
+    </Dialog>,
+    document.body // 모달을 body에 렌더링
+  );
+}
+
+const fadeIn = keyframes`
+  0% {
+    transform: scale(0.9) translate(-55%, -60%);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1) translate(-50%, -50%);
+    opacity: 1;
+  }
+`;
+
+const fadeOut = keyframes`
+  0% {
+    transform: scale(1) translate(-50%, -50%);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(0.9) translate(-55%, -60%);
+    opacity: 0;
+  }
+`;
+
+const showBackdrop = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+`;
+
+const Dialog = styled.dialog<{ $isOpen: boolean }>`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 0;
+  margin: 0;
+  border: none;
+  background-color: transparent;
+  animation: ${({ $isOpen }) => ($isOpen ? fadeIn : fadeOut)} 0.4s ease;
+  outline: none;
+
+  $[open] {
+    outline: none;
+  }
+
+  &[open]::backdrop {
+    animation: ${showBackdrop} 0.4s ease;
+  }
+
+  &::backdrop {
+    background-color: rgba(255, 255, 255, 0.7);
+  }
+`;

--- a/src/shared/components/modal/Modal.tsx
+++ b/src/shared/components/modal/Modal.tsx
@@ -112,7 +112,7 @@ const Dialog = styled.dialog<{ $isOpen: boolean }>`
   animation: ${({ $isOpen }) => ($isOpen ? fadeIn : fadeOut)} 0.4s ease;
   outline: none;
 
-  $[open] {
+  &[open] {
     outline: none;
   }
 

--- a/src/shared/hooks/useClickOutside.ts
+++ b/src/shared/hooks/useClickOutside.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+
+const useClickOutside = (
+  dropdownRef: React.RefObject<HTMLDivElement>,
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>
+) => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        // 필터 메뉴 DOM이 화면에 렌더링 되어 있고
+        dropdownRef.current &&
+        // 현재 클릭된 위치가 필터 메뉴 외부일 때
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    // mousedown(마우스 버튼이 눌린 순간) 이벤트가 발생할 때마다 함수
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [dropdownRef]);
+};
+
+export default useClickOutside;

--- a/src/shared/hooks/useToggle.ts
+++ b/src/shared/hooks/useToggle.ts
@@ -1,0 +1,13 @@
+import { useCallback, useState } from "react";
+
+const useToggle = (initialState = false) => {
+  const [isOpen, setIsOpen] = useState<boolean>(initialState);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  return { isOpen, setIsOpen, toggle };
+};
+
+export default useToggle;

--- a/src/shared/types/components.types.ts
+++ b/src/shared/types/components.types.ts
@@ -1,3 +1,4 @@
+// 버튼
 interface IButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
   width?: number;
@@ -6,4 +7,11 @@ interface IButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   disabled?: boolean;
 }
 
-export type { IButtonProps };
+// 모달
+interface IModalProps {
+  children: React.ReactNode;
+  isOpen: boolean;
+  toggle: () => void;
+}
+
+export type { IButtonProps, IModalProps };


### PR DESCRIPTION
### 작업 내용 요약
모달 공통 컴포넌트 구현

모달을 공통 컴포넌트로 분리하여 재사용할 수 있도록 구현했습니다.
해당 컴포넌트는 외부 영역 클릭 및 닫기 버튼을 통한 모달 닫기 기능을 포함하고 있습니다.


https://github.com/user-attachments/assets/cafbe67d-85b4-4ae5-8bb2-1537cb23b824

<br>

### 사용 방법

**코드 예시**

```ts
import Modal from '@/shared/components/modal/Modal';
import useToggle from '@/shared/hooks/useToggle';
import styled from "@emotion/styled";

export function ModalTestPage() {
  const { isOpen, toggle } = useToggle();

  return (
    <div>
      <button onClick={toggle}>Modal Open</button>

      <Modal isOpen={isOpen} toggle={toggle}>
        <ModalWrapper>
          <p>hi</p>
          <ClosedBtn onClick={toggle}>close</ClosedBtn>
        </ModalWrapper>
      </Modal>
    </div>
  );
}

const ModalWrapper = styled.div`
  position: relative;
  width: 552px;
  height: 168px;
`;

const ClosedBtn = styled.button`
  position: absolute;
  top: 10px;
  right: 10px;
`;

```

### 1. `Modal`을 import 해온다
`Modal` 컴포넌트 내부에는 크게 두가지 기능을 로직으로 구현해두었습니다.
(자세한 로직은 코드 내 주석 참고 바랍니다)

- 바깥 클릭 시 모달 닫기 기능
- 닫기 버튼 클릭 시 모달 닫기 기능

열고 닫히는 로직은 `useToggle` 훅을 통해 구현해두었으니 import 해주셔야 합니다.

<br>

### 2. `Modal` 컴포넌트에 `isOpen`과 `toggle` 상태를 내려준다

<br>

### 3. `Modal` 컴포넌트의 자식 요소로 컨테이너를 하나 생성 (ex. `ModalWrapper`)하여 자유롭게 커스텀 스타일링한다.

<br>

### 4. 닫기 버튼이나, 특정 버튼을 눌러서 닫고 싶을 때는 

```ts
          <ClosedBtn onClick={toggle}>close</ClosedBtn>
```
버튼을 생성하여 `onClick` 속성에 `toggle`을 내려준다



<br>

---

### 공유할 사항
공통 컴포넌트는 지라에서 따로 `공통 컴포넌트` 에픽 이슈를 만들어서 작업했으니 참고해주세요!

